### PR TITLE
Fix npm auto release on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,14 +41,13 @@ jobs:
   # (from: https://circleci.com/blog/publishing-npm-packages-using-circleci-2-0/)
   npm_publish:
     docker:
-    - image: node:10-alpine
+    - image: circleci/node:10
     steps:
-      - run: apk add git openssh-client
       - checkout
       - run: npm install
       - run:
           name: Authenticate with registry
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > /root/.npmrc
+          command: echo -e "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
       - run: npm publish
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 ANCHORS:
  node_steps: &node_steps
    steps:
-     - run: apk add git openssh-client
      - checkout
      - run: npm install
      - run: npm test
@@ -12,12 +11,12 @@ version: 2
 jobs:
   node_10:
     docker:
-      - image: node:10-alpine 
+      - image: circleci/node:10
     <<: *node_steps
   
   node_8:
     docker:
-      - image: node:8-alpine 
+      - image: circleci/node:8
     <<: *node_steps
   
   docker_test:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "tsc",
     "start": "npm run build && node dist/src/index.js",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "test": "mocha --require ts-node/register --timeout 10000 test/**/*.ts"
   },
   "keywords": [


### PR DESCRIPTION
## Problem

`.circleci/config.yml` had the following problem in "npm_publish" job. (see: "npm publish" in https://circleci.com/gh/nwtgck/piping-server/466)

```
piping-server@0.5.0~prepublish: cannot run in wd piping-server@0.5.0 npm run build (wd=.)
```

This problem was caused by `npm publish` by root user.

## Solution

This PR solves the problem above by using `circleci/node:10` in "npm_release" job. Default user of `circleci/node:10` is not root user.