### PR TITLE
Support /help routing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ const enableLog: boolean = args['enable-log'];
 // Create a piping server
 const pipingServer = new piping.Server(enableLog);
 
-http.createServer(pipingServer.handler)
+http.createServer(pipingServer.generateHandler(false))
   .listen(httpPort, ()=>{
     console.log(`Listen HTTP on ${httpPort}...`);
   });
@@ -62,7 +62,7 @@ if (enableHttps && httpsPort !== undefined) {
         key: fs.readFileSync(serverKeyPath),
         cert: fs.readFileSync(serverCrtPath)
       },
-      pipingServer.handler
+      pipingServer.generateHandler(true)
     ).listen(httpsPort, ()=>{
       console.log(`Listen HTTPS on ${httpsPort}...`);
     });

--- a/src/piping.ts
+++ b/src/piping.ts
@@ -6,7 +6,7 @@ import 'core-js'; // NOTE: For use Object.values() under node 6 (lib: ["es2017"]
 import * as pkginfo from "pkginfo";
 import * as Busboy from "busboy";
 
-import {opt, optMap, tryOpt} from "./utils";
+import {opt, optMap} from "./utils";
 import * as path from "path";
 
 // Set module.exports.version
@@ -273,8 +273,13 @@ curl ${url}/mypath | openssl aes-256-cbc -d
               res.end(VERSION+"\n");
               break;
             case NAME_TO_RESERVED_PATH.help:
-              // TODO: Support X-Forwarded-Proto
-              const scheme: string = useHttps ? "https" : "http";
+              // x-forwarded-proto is https or not
+              const xForwardedProtoIsHttps: boolean = (()=>{
+                const proto = req.headers["x-forwarded-proto"];
+                // NOTE: includes() is for supporting Glitch
+                return proto !== undefined && proto.includes("https")
+              })();
+              const scheme: string = (useHttps || xForwardedProtoIsHttps) ? "https" : "http";
               // NOTE: req.headers.host contains port number
               const hostname: string = req.headers.host || "hostname";
               const url = `${scheme}://${hostname}`;

--- a/src/piping.ts
+++ b/src/piping.ts
@@ -12,6 +12,9 @@ import * as path from "path";
 // Set module.exports.version
 pkginfo(module, 'version');
 
+// Get version
+const VERSION: string = module.exports.version;
+
 type ReqRes = {
   readonly req: http.IncomingMessage,
   readonly res: http.ServerResponse
@@ -69,7 +72,8 @@ function nanOrElse<T>(a: number, b: number): number {
 // Name to reserved path
 const NAME_TO_RESERVED_PATH = {
   index: "/",
-  version: "/version"
+  version: "/version",
+  help: "/help"
 };
 
 // All reserved paths
@@ -117,6 +121,39 @@ export class Server {
     </body>
     </html>
     `;
+
+  /**
+   * Generate help page
+   * @param {string} url
+   * @returns {string}
+   */
+  static generateHelpPage(url: string): string {
+    return `Help for piping-server ${VERSION}
+(Repository: https://github.com/nwtgck/piping-server)
+
+======= Get  =======
+curl ${url}/mypath
+
+======= Send =======
+# Send a file
+curl -T myfile ${url}/mypath
+
+# Send a text
+echo 'hello!' | curl -T - ${url}/mypath
+
+# Send a directory (zip)
+zip -q -r - ./mydir | curl -T - ${url}/mypath
+
+# Send a directory (tar.gz)
+tar zfcp - ./mydir | curl -T - ${url}/mypath
+
+# Encryption
+## Send
+cat myfile | openssl aes-256-cbc | curl -T - ${url}/mypath
+## Get
+curl ${url}/mypath | openssl aes-256-cbc -d
+`
+  }
 
   /**
    *
@@ -203,48 +240,58 @@ export class Server {
     });
   }
 
-  readonly handler = (req: http.IncomingMessage, res: http.ServerResponse)=>{
-    // Get path name
-    const reqPath: string =
-      path.resolve(
-        "/",
-        opt(optMap(url.parse, opt(req.url)).pathname)
-        // Remove last "/"
-          .replace(/\/$/, "")
-      );
-    if (this.enableLog) console.log(req.method, reqPath);
+  generateHandler(useHttps: boolean): (req: http.IncomingMessage, res: http.ServerResponse) => void {
+    return (req: http.IncomingMessage, res: http.ServerResponse)=>{
+      // Get path name
+      const reqPath: string =
+          path.resolve(
+              "/",
+              opt(optMap(url.parse, opt(req.url)).pathname)
+              // Remove last "/"
+              .replace(/\/$/, "")
+          );
+      if (this.enableLog) console.log(req.method, reqPath);
 
-    switch (req.method) {
-      case "POST":
-      case "PUT":
-        if(RESERVED_PATHS.includes(reqPath)) {
-          res.writeHead(400);
-          res.end(`[ERROR] Cannot send to a reserved path '${reqPath}'. (e.g. '/mypath123')\n`);
-        } else {
-          // Handle a sender
-          this.handleSender(req, res, reqPath);
-        }
-        break;
-      case "GET":
-        switch (reqPath) {
-          case NAME_TO_RESERVED_PATH.index:
-            res.end(Server.indexPage);
-            break;
-          case NAME_TO_RESERVED_PATH.version:
-            // (from: https://stackoverflow.com/a/22339262/2885946)
-            res.end(module.exports.version+"\n");
-            break;
-          default:
-            // Handle a receiver
-            this.handleReceiver(req, res, reqPath);
-            break;
-        }
-        break;
-      default:
-        res.end(`Error: Unsupported method: ${req.method}\n`);
-        break;
-    }
-  };
+      switch (req.method) {
+        case "POST":
+        case "PUT":
+          if(RESERVED_PATHS.includes(reqPath)) {
+            res.writeHead(400);
+            res.end(`[ERROR] Cannot send to a reserved path '${reqPath}'. (e.g. '/mypath123')\n`);
+          } else {
+            // Handle a sender
+            this.handleSender(req, res, reqPath);
+          }
+          break;
+        case "GET":
+          switch (reqPath) {
+            case NAME_TO_RESERVED_PATH.index:
+              res.end(Server.indexPage);
+              break;
+            case NAME_TO_RESERVED_PATH.version:
+              // (from: https://stackoverflow.com/a/22339262/2885946)
+              res.end(VERSION+"\n");
+              break;
+            case NAME_TO_RESERVED_PATH.help:
+              // TODO: Support X-Forwarded-Proto
+              const scheme: string = useHttps ? "https" : "http";
+              // NOTE: req.headers.host contains port number
+              const hostname: string = req.headers.host || "hostname";
+              const url = `${scheme}://${hostname}`;
+              res.end(Server.generateHelpPage(url));
+              break;
+            default:
+              // Handle a receiver
+              this.handleReceiver(req, res, reqPath);
+              break;
+          }
+          break;
+        default:
+          res.end(`Error: Unsupported method: ${req.method}\n`);
+          break;
+      }
+    };
+  }
 
   /** Get the number of receivers
    * @param {string | undefined} reqUrl

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -48,7 +48,7 @@ describe('piping.Server', () => {
     // Define Piping URL
     pipingUrl = `http://localhost:${pipingPort}`;
     // Create a Piping server
-    pipingServer = http.createServer(new piping.Server(false).handler);
+    pipingServer = http.createServer(new piping.Server(false).generateHandler(false));
     // Listen on the port
     await listenPromise(pipingServer, pipingPort);
   });

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -78,6 +78,14 @@ describe('piping.Server', () => {
       assert.equal(res.getBody("UTF-8"), module.exports.version+"\n");
     });
 
+    it('should return help page', async () => {
+      // Get response
+      const res = await thenRequest("GET", `${pipingUrl}/help`);
+
+      // Status should be OK
+      assert.equal(res.statusCode, 200);
+    });
+
     it('should not allow user to send the reserved paths', async () => {
       // Send data to ""
       const req1 = await thenRequest("POST", `${pipingUrl}`, {


### PR DESCRIPTION
## Added
* Add /help routing

### Example

Here is an example of `/help`.

```txt
Help for piping-server 0.5.2-SNAPSHOT
(Repository: https://github.com/nwtgck/piping-server)

======= Get  =======
curl http://localhost:8080/mypath

======= Send =======
# Send a file
curl -T myfile http://localhost:8080/mypath

# Send a text
echo 'hello!' | curl -T - http://localhost:8080/mypath

# Send a directory (zip)
zip -q -r - ./mydir | curl -T - http://localhost:8080/mypath

# Send a directory (tar.gz)
tar zfcp - ./mydir | curl -T - http://localhost:8080/mypath

# Encryption
## Send
cat myfile | openssl aes-256-cbc | curl -T - http://localhost:8080/mypath
## Get
curl http://localhost:8080/mypath | openssl aes-256-cbc -d
```
A scheme such as "http" or "https" and URL will be changed by a server, which supports X-Forwarded-Proto header.