### PR TITLE
Remove core-js from dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -333,7 +333,8 @@
     "core-js": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.2.tgz",
-      "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g=="
+      "integrity": "sha512-NdBPF/RVwPW6jr0NCILuyN9RiqLo2b1mddWHkUL+VnvcB7dzlnBJ1bXYntjpTGOgkZiiLWj2JxmOr7eGE3qK6g==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "busboy": "^0.3.0",
-    "core-js": "^2.5.7",
     "pkginfo": "^0.4.1",
     "yargs": "^12.0.2"
   }

--- a/src/piping.ts
+++ b/src/piping.ts
@@ -2,7 +2,6 @@ import * as http from "http";
 import * as url from "url";
 import * as stream from "stream";
 import {ParsedUrlQuery} from "querystring";
-import 'core-js'; // NOTE: For use Object.values() under node 6 (lib: ["es2017"] is not enough)
 import * as pkginfo from "pkginfo";
 import * as Busboy from "busboy";
 


### PR DESCRIPTION
## Removed
- Remove core-js from dependencies because core-js isn't needed in node 8 or later.