### PR TITLE
Fix not to pass "undefined" if content-type in multipart is not present

### DIFF
--- a/src/piping.ts
+++ b/src/piping.ts
@@ -304,7 +304,10 @@ export class Server {
               part.byteCount === undefined ?
                 {} : {"Content-Length": part.byteCount}
             ),
-            "Content-Type": part.headers["content-type"]
+            ...(
+              part.headers["content-type"] === undefined ?
+                {} : {"Content-Type": part.headers["content-type"]}
+            )
           };
 
       // Write headers to a receiver

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -676,7 +676,24 @@ describe("piping.Server", () => {
   });
 
   context("By multipart/data-form", () => {
-    it("should allow sender to send data via multipart", async () => {
+    it("should allow sender to send data via multipart without multipart content-type", async () => {
+      const formData = {
+        "dummy form name": "this is a content"
+      };
+
+      // Send data
+      request.post({url: `${pipingUrl}/mydataid`, formData: formData});
+
+      await sleep(10);
+
+      const getPromise1 = thenRequest("GET", `${pipingUrl}/mydataid`);
+
+      const getData1 = await getPromise1;
+      assert.equal(getData1.statusCode, 200);
+      assert.equal(getData1.getBody("UTF-8"), "this is a content");
+    });
+
+    it("should pass sender's Content-Type to receivers' one", async () => {
       const formData = {
         "dummy form name": {
           value: "this is a content",
@@ -695,7 +712,6 @@ describe("piping.Server", () => {
 
       const getData1 = await getPromise1;
       assert.equal(getData1.statusCode, 200);
-      assert.equal(getData1.getBody("UTF-8"), "this is a content");
       assert.equal(getData1.headers["content-type"], "text/plain");
     });
   });


### PR DESCRIPTION
## Fixed
* Fix not to pass "undefined" if content-type in multipart is not present

## Test
* Ensure to send data via multipart without multipart content-type