### PR TITLE
Not to use pkginfo package to extract "version" in package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /node_modules
 /dist
+/src/version.ts
 
 /ssl_certs

--- a/package-lock.json
+++ b/package-lock.json
@@ -1505,7 +1505,8 @@
     "pkginfo": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.4.1.tgz",
-      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8="
+      "integrity": "sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=",
+      "dev": true
     },
     "power-assert": {
       "version": "1.6.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "main": "dist/src/piping.js",
   "types": "dist/src/piping.d.ts",
   "scripts": {
-    "build": "tsc",
+    "generate-version": "echo \"export const VERSION = \\\"$npm_package_version\\\";\" > src/version.ts",
+    "build": "npm run generate-version && tsc",
     "start": "npm run build && node dist/src/index.js",
     "lint": "tslint 'src/**/*.ts' && tslint 'test/**/*.ts'",
     "prepare": "npm run build",
@@ -37,6 +38,7 @@
     "espower-typescript": "^9.0.0",
     "get-port": "^4.0.0",
     "mocha": "^5.0.5",
+    "pkginfo": "^0.4.1",
     "power-assert": "^1.4.4",
     "request": "^2.88.0",
     "then-request": "^6.0.0",
@@ -46,7 +48,6 @@
   },
   "dependencies": {
     "multiparty": "^4.2.1",
-    "pkginfo": "^0.4.1",
     "yargs": "^12.0.2"
   }
 }

--- a/src/piping.ts
+++ b/src/piping.ts
@@ -1,19 +1,12 @@
 import * as http from "http";
 import * as multiparty from "multiparty";
-import * as pkginfo from "pkginfo";
 import {ParsedUrlQuery} from "querystring";
 import * as stream from "stream";
 import * as url from "url";
 
 import * as path from "path";
 import {opt, optMap} from "./utils";
-
-// Set module.exports.version
-pkginfo(module, "version");
-
-// Get version
-// (from: https://stackoverflow.com/a/22339262/2885946)
-const VERSION: string = module.exports.version;
+import {VERSION} from "./version";
 
 type ReqRes = {
   readonly req: http.IncomingMessage,


### PR DESCRIPTION
## Refactor
* Not to use `pkginfo` package to extract "version" in package.json

The main reason not to use `pkaginfo` is for parcel-bundler. `parcel` is going to be used in [bytenode-piping-server](https://github.com/nwtgck/bytenode-piping-server). Another reason is that I feel not so good to rely on external files such as package.json not only .js files or assets. Project administrator should always be careful about external files.
