### PR TITLE
Return 204 No Content when user gets /favicon.ico

### DIFF
--- a/src/piping.ts
+++ b/src/piping.ts
@@ -66,7 +66,8 @@ function nanOrElse<T>(a: number, b: number): number {
 const NAME_TO_RESERVED_PATH = {
   index: "/",
   version: "/version",
-  help: "/help"
+  help: "/help",
+  faviconIco: "/favicon.ico"
 };
 
 const indexPage: string =
@@ -254,6 +255,11 @@ export class Server {
               // tslint:disable-next-line:no-shadowed-variable
               const url = `${scheme}://${hostname}`;
               res.end(generateHelpPage(url));
+              break;
+            case NAME_TO_RESERVED_PATH.faviconIco:
+              // (from: https://stackoverflow.com/a/35408810/2885946)
+              res.writeHead(204);
+              res.end();
               break;
             default:
               // Handle a receiver

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -85,6 +85,14 @@ describe("piping.Server", () => {
       assert.equal(res.statusCode, 200);
     });
 
+    it("should return no favicon", async () => {
+      // Get response
+      const res = await thenRequest("GET", `${pipingUrl}/favicon.ico`);
+
+      // Status should be No Content
+      assert.equal(res.statusCode, 204);
+    });
+
     it("should not allow user to send the reserved paths", async () => {
       // Send data to ""
       const req1 = await thenRequest("POST", `${pipingUrl}`, {


### PR DESCRIPTION
## Changed
* Return 204 No Content when user gets /favicon.ico

## Purpose

The purpose of the PR is as follows.
* Prevent future vulnerability of .ico reader

I have heard some .png reader has vulnerabilities such as executing arbitrary program. Some browsers access /favicon.ico automatically, so users unconsciously do `GET /favicon.ico`. So a bad guy can do `POST /favicon.ico` which has a bad program. This is just my assumption. I'm not sure .ico reader can have vulnerabilities or not. 
