### PR TITLE
Pass sender's Content-Disposition to receivers' one in both POST/PUT and multipart

### DIFF
--- a/src/piping.ts
+++ b/src/piping.ts
@@ -339,6 +339,11 @@ export class Server {
             ...(
               sender.req.headers["content-type"] === undefined ?
                 {} : {"Content-Type": sender.req.headers["content-type"]}
+            ),
+            // Add Content-Disposition if it exists
+            ...(
+              sender.req.headers["content-disposition"] === undefined ?
+                {} : {"Content-Disposition": sender.req.headers["content-disposition"]}
             )
           } :
           {
@@ -351,6 +356,11 @@ export class Server {
             ...(
               part.headers["content-type"] === undefined ?
                 {} : {"Content-Type": part.headers["content-type"]}
+            )
+            ,
+            ...(
+              part.headers["content-disposition"] === undefined ?
+                {} : {"Content-Disposition": part.headers["content-disposition"]}
             )
           };
 

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -144,6 +144,25 @@ describe("piping.Server", () => {
     assert.equal(data.headers["content-type"], "text/plain");
   });
 
+  it("should pass sender's Content-Disposition to receivers' one", async () => {
+    // Get request promise
+    const reqPromise = thenRequest("GET", `${pipingUrl}/mydataid`);
+
+    // Send data
+    await thenRequest("POST", `${pipingUrl}/mydataid`, {
+      headers: {
+        "content-disposition": "attachment; filename=\"myfile.txt\""
+      },
+      body: "this is a content"
+    });
+
+    // Get data
+    const data = await reqPromise;
+
+    // Content-Disposition should be returned
+    assert.equal(data.headers["content-disposition"], "attachment; filename=\"myfile.txt\"");
+  });
+
   it("should have Access-Control-Allow-Origin headers in GET/POST response", async () => {
     // Get request promise
     const reqPromise = thenRequest("GET", `${pipingUrl}/mydataid`);

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -750,5 +750,28 @@ describe("piping.Server", () => {
       assert.equal(getData1.statusCode, 200);
       assert.equal(getData1.headers["content-type"], "text/plain");
     });
+
+    it("should pass sender's Content-Disposition to receivers' one", async () => {
+      const formData = {
+        "dummy form name": {
+          value: "this is a content",
+          options: {
+            filename: "myfile.txt"
+          }
+        }
+      };
+
+      // Send data
+      request.post({url: `${pipingUrl}/mydataid`, formData: formData});
+
+      await sleep(10);
+
+      const getPromise1 = thenRequest("GET", `${pipingUrl}/mydataid`);
+
+      const getData1 = await getPromise1;
+      assert.equal(getData1.statusCode, 200);
+      const contentDisposition = "form-data; name=\"dummy form name\"; filename=\"myfile.txt\"";
+      assert.equal(getData1.headers["content-disposition"], contentDisposition);
+    });
   });
 });


### PR DESCRIPTION
## Added
* Pass sender's Content-Disposition to receivers' one in both POST/PUT and multipart


## Detail
`Content-Disposition` header in sender's request is passed to the receivers' header. By this PR, a sender can specify "attachment" or "inline" and file name, which are used in a download.