### PR TITLE
Not to allow user to send "/robots.txt" and  return 404 when user access to "/rebots.txt"

### DIFF
--- a/src/piping.ts
+++ b/src/piping.ts
@@ -67,7 +67,8 @@ const NAME_TO_RESERVED_PATH = {
   index: "/",
   version: "/version",
   help: "/help",
-  faviconIco: "/favicon.ico"
+  faviconIco: "/favicon.ico",
+  robotsTxt: "/robots.txt"
 };
 
 const indexPage: string =
@@ -261,6 +262,9 @@ export class Server {
               res.writeHead(204);
               res.end();
               break;
+            case NAME_TO_RESERVED_PATH.robotsTxt:
+              res.writeHead(404);
+              res.end();
             default:
               // Handle a receiver
               this.handleReceiver(req, res, reqPath);

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -93,8 +93,16 @@ describe("piping.Server", () => {
       assert.equal(res.statusCode, 204);
     });
 
+    it("should return no robots.txt", async () => {
+      // Get response
+      const res = await thenRequest("GET", `${pipingUrl}/robots.txt`);
+
+      // Status should not be found
+      assert.equal(res.statusCode, 404);
+    });
+
     it("should not allow user to send the reserved paths", async () => {
-      const reservedPaths = ["", "/", "/version", "/help", "/favicon.ico"];
+      const reservedPaths = ["", "/", "/version", "/help", "/favicon.ico", "/robots.txt"];
 
       for (const reservedPath of reservedPaths) {
         // Send data to ""


### PR DESCRIPTION
## Changed
* Not to allow user to send "/robots.txt" and  return 404 when user access to "/rebots.txt"

Some crawlers or bots access to `"/robots.txt"`. Currently, users can send `"/robots.txt"`. This PR doesn't allow user to send and get `"/robots.txt"` GET "/robots.txt" returns 404. POST/PUT "/robots.txt" returns 400 Bad Request.