### PR TITLE
Add sleep() to fix CORS test

### DIFF
--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -175,6 +175,8 @@ describe("piping.Server", () => {
     // Get request promise
     const reqPromise = thenRequest("GET", `${pipingUrl}/mydataid`);
 
+    await sleep(10);
+
     // Send data
     const postRes = await thenRequest("POST", `${pipingUrl}/mydataid`, {
       body: "this is a content"


### PR DESCRIPTION
## Fixed
* Fix CORS test by adding `sleep(10)`

Sometimes, the test was failed because it's a timing problem of GET and POST. `sleep(10)`, 10 msec adjusted the timing properly. I confirmed by ` yes 'npm test' | sh` loop by visual.