### PR TITLE
Use ReadonlyArray<> in Pipe for improving safety

### DIFF
--- a/src/piping.ts
+++ b/src/piping.ts
@@ -15,7 +15,7 @@ type ReqRes = {
 
 type Pipe = {
   readonly sender: ReqRes;
-  readonly receivers: ReqRes[];
+  readonly receivers: ReadonlyArray<ReqRes>;
 };
 
 type ReqResAndUnsubscribe = {


### PR DESCRIPTION
## Refactor
* Use `ReadonlyArray<>` in Pipe for improving safety

The `receivers` array in `UnestablishedPipe` is mutable. However, the `receivers` array in `Pipe` is immutable. For safety, `ReadonlyArray` was used in `Pipe`.