### PR TITLE
Allow user to ctrl-c to terminate piping-server docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM node:10.15-alpine
 
 LABEL maintainer="Ryo Ota <nwtgck@gmail.com>"
 
+RUN apk add --no-cache tini
+
 COPY . /app
 
 # Move to /app
@@ -13,5 +15,5 @@ RUN npm install && \
     npm run build && \
     npm prune --production
 
-# Run entry (Run the server)
-ENTRYPOINT ["node", "dist/src/index.js"]
+# Run a server
+ENTRYPOINT [ "tini", "--", "node", "dist/src/index.js" ]


### PR DESCRIPTION
## Fixed
* Allow user to ctrl-c to terminate piping-server docker container

This PR uses [`tini`](https://github.com/krallin/tini) to solve <kbd>ctrl</kbd>-<kbd>c</kbd> problem, and it's the best practice introduced in the official Node.js repo, [nodejs/docker-node/docs/BestPactices.md](https://github.com/nodejs/docker-node/blob/master/docs/BestPractices.md).

Before this PR, docker users should use <kbd>ctrl</kbd>-<kbd>p</kbd> + <kbd>ctrl</kbd>-<kbd>q</kbd> to detach or `docker ps`, `docker stop` in other terminal. This PR solves the problem.

## Image sizes

Here are images size comparing before and after this PR. As you see, both of them have the same size.

### Before this PR
```
piping-with-ctrc-issue   latest              2b40a8a70b5a        13 minutes ago      88.8MB
```

### After this PR
```
piping-with-tini         latest              e7e0dd407a53        11 minutes ago      88.8MB
```



## Reference
* [Japanese] <http://ngzm.hateblo.jp/entry/2017/08/22/185224>
  - [Google Translation](https://translate.google.com/translate?hl=ja&sl=ja&tl=en&u=http%3A%2F%2Fngzm.hateblo.jp%2Fentry%2F2017%2F08%2F22%2F185224)