### PR TITLE
Return "Content-Length" and "Content-Type" when accessing index, /version and /help

### DIFF
--- a/src/piping.ts
+++ b/src/piping.ts
@@ -238,10 +238,19 @@ export class Server {
         case "GET":
           switch (reqPath) {
             case NAME_TO_RESERVED_PATH.index:
+              res.writeHead(200, {
+                "Content-Length": Buffer.byteLength(indexPage),
+                "Content-Type": "text/html"
+              });
               res.end(indexPage);
               break;
             case NAME_TO_RESERVED_PATH.version:
-              res.end(VERSION + "\n");
+              const versionPage: string = VERSION + "\n";
+              res.writeHead(200, {
+                "Content-Length": Buffer.byteLength(versionPage),
+                "Content-Type": "text/plain"
+              });
+              res.end(versionPage);
               break;
             case NAME_TO_RESERVED_PATH.help:
               // x-forwarded-proto is https or not
@@ -255,7 +264,13 @@ export class Server {
               const hostname: string = req.headers.host || "hostname";
               // tslint:disable-next-line:no-shadowed-variable
               const url = `${scheme}://${hostname}`;
-              res.end(generateHelpPage(url));
+
+              const helpPage: string = generateHelpPage(url);
+              res.writeHead(200, {
+                "Content-Length": Buffer.byteLength(helpPage),
+                "Content-Type": "text/plain"
+              });
+              res.end(helpPage);
               break;
             case NAME_TO_RESERVED_PATH.faviconIco:
               // (from: https://stackoverflow.com/a/35408810/2885946)

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -63,6 +63,14 @@ describe("piping.Server", () => {
       // Body should be index page
       assert.equal(res1.getBody("UTF-8").includes("Piping"), true);
       assert.equal(res2.getBody("UTF-8").includes("Piping"), true);
+
+      // Should have "Content-Length"
+      assert.strictEqual(res1.headers["content-length"], Buffer.byteLength(res1.getBody("UTF-8")).toString());
+      assert.strictEqual(res2.headers["content-length"], Buffer.byteLength(res2.getBody("UTF-8")).toString());
+
+      // Should have "Content-Type"
+      assert.strictEqual(res1.headers["content-type"], "text/html");
+      assert.strictEqual(res2.headers["content-type"], "text/html");
     });
 
     it("should return version page", async () => {
@@ -72,11 +80,21 @@ describe("piping.Server", () => {
       // Body should be index page
       // (from: https://stackoverflow.com/a/22339262/2885946)
       assert.equal(res.getBody("UTF-8"), VERSION + "\n");
+
+      // Should have "Content-Length"
+      assert.strictEqual(res.headers["content-length"], Buffer.byteLength(res.getBody("UTF-8")).toString());
+      // Should have "Content-Type"
+      assert.strictEqual(res.headers["content-type"], "text/plain");
     });
 
     it("should return help page", async () => {
       // Get response
       const res = await thenRequest("GET", `${pipingUrl}/help`);
+
+      // Should have "Content-Length"
+      assert.strictEqual(res.headers["content-length"], Buffer.byteLength(res.getBody("UTF-8")).toString());
+      // Should have "Content-Type"
+      assert.strictEqual(res.headers["content-type"], "text/plain");
 
       // Status should be OK
       assert.equal(res.statusCode, 200);


### PR DESCRIPTION
## Changed
* Return "Content-Length" and "Content-Type" when accessing index, /version and /help

Before this PR, there is no "Content-Length", but it has "Transfer-Encoding: chunked". 