### PR TITLE
Remove @types/get-port

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,12 +34,6 @@
         "@types/node": "*"
       }
     },
-    "@types/get-port": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/get-port/-/get-port-4.0.0.tgz",
-      "integrity": "sha512-Zp1GxOt3GNbIQqz2hSHSH7LALpTPvPHMA/aYut3VeitDgGwqcXEVvDQWWP3kPABsh3CGSHPSt67DN6jnc7oJMA==",
-      "dev": true
-    },
     "@types/mocha": {
       "version": "5.2.6",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   "author": "Ryo Ota",
   "license": "MIT",
   "devDependencies": {
-    "@types/get-port": "4.0.0",
     "@types/mocha": "^5.0.0",
     "@types/node": "^10.12.21",
     "@types/power-assert": "^1.5.0",

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -1,4 +1,4 @@
-import * as getPort from "get-port";
+import getPort from "get-port";
 import * as http from "http";
 import * as assert from "power-assert";
 import * as request from "request";


### PR DESCRIPTION
## Refactor
* Remove @types/get-port

A type definition of `get-port` is officially supported.
see: https://github.com/sindresorhus/get-port/pull/27