### PR TITLE
Fix sender's header to have "Access-Control-Allow-Origin: *"

### DIFF
--- a/src/piping.ts
+++ b/src/piping.ts
@@ -482,6 +482,10 @@ export class Server {
           res.end(`[ERROR] Another sender has been registered on '${reqPath}'.\n`);
         }
       } else {
+        // Add headers
+        res.writeHead(200, {
+          "Access-Control-Allow-Origin": "*"
+        });
         // Send waiting message
         res.write(`[INFO] Waiting for ${nReceivers} receiver(s)...\n`);
         // Create a sender

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -207,6 +207,27 @@ describe("piping.Server", () => {
     assert.strictEqual(data.headers["access-control-allow-origin"], "*");
   });
 
+  it("should have Access-Control-Allow-Origin headers in POST/GET response", async () => {
+    // Send data
+    const postResPromise = thenRequest("POST", `${pipingUrl}/mydataid`, {
+      body: "this is a content"
+    });
+
+    await sleep(10);
+
+    // Get request promise
+    const getRes = await thenRequest("GET", `${pipingUrl}/mydataid`);
+
+    // Headers of GET response should have Access-Control-Allow-Origin
+    assert.strictEqual(getRes.headers["access-control-allow-origin"], "*");
+
+    // Get response
+    const postRes = await postResPromise;
+
+    // Headers of POST response should have Access-Control-Allow-Origin
+    assert.strictEqual(postRes.headers["access-control-allow-origin"], "*");
+  });
+
   it("should handle connection (sender: O, receiver: O)", async () => {
     // Send data
     // (NOTE: Should NOT use `await` because of blocking a GET request)


### PR DESCRIPTION
## Fixed
* Fix sender's header to have "Access-Control-Allow-Origin: *"

When an access order is "sender => receiver" , there is no `Access-Control-Allow-Origin: *`.
So, this fixes the issue above. On the other hand, when an access order is "receiver => sender" ,  `Access-Control-Allow-Origin: *` has already existed.
