### PR TITLE
HTTP/2 Support over HTTPS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 
 import * as fs from "fs";
 import * as http from "http";
-import * as http2 from 'http2';
+import * as http2 from "http2";
 import * as yargs from "yargs";
 
 import * as piping from "./piping";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
 
 import * as fs from "fs";
 import * as http from "http";
-import * as https from "https";
+import * as http2 from 'http2';
 import * as yargs from "yargs";
 
 import * as piping from "./piping";
@@ -57,7 +57,7 @@ if (enableHttps && httpsPort !== undefined) {
   if (serverKeyPath === undefined || serverCrtPath === undefined) {
     console.error("Error: --key-path and --crt-path should be specified");
   } else {
-    https.createServer(
+    http2.createSecureServer(
       {
         key: fs.readFileSync(serverKeyPath),
         cert: fs.readFileSync(serverCrtPath)

--- a/src/piping.ts
+++ b/src/piping.ts
@@ -427,7 +427,9 @@ export class Server {
       }
       for (const receiver of receivers) {
         // Close a receiver
-        receiver.res.connection.destroy();
+        if (receiver.res.connection !== undefined) {
+          receiver.res.connection.destroy();
+        }
       }
     });
 

--- a/src/piping.ts
+++ b/src/piping.ts
@@ -494,7 +494,9 @@ export class Server {
             }
           } else {
             res.writeHead(400);
-            res.end(`[ERROR] The number of receivers should be ${unestablishedPipe.nReceivers} but ${nReceivers}.\n` as any);
+            res.end(
+              `[ERROR] The number of receivers should be ${unestablishedPipe.nReceivers} but ${nReceivers}.\n` as any
+            );
           }
         } else {
           res.writeHead(400);
@@ -568,7 +570,9 @@ export class Server {
           }
         } else {
           res.writeHead(400);
-          res.end(`[ERROR] The number of receivers should be ${unestablishedPipe.nReceivers} but ${nReceivers}.\n` as any);
+          res.end(
+            `[ERROR] The number of receivers should be ${unestablishedPipe.nReceivers} but ${nReceivers}.\n` as any
+          );
         }
       } else {
         // Create a receiver


### PR DESCRIPTION
## Added
* Support HTTP/2 over HTTPS

## Why only HTTPS

Because this is Node.js limitation. Here is a test in official Node.js repo:
<https://github.com/nodejs/node/blob/655c90b287375d7920f509136d7a75492739dd2a/test/parallel/test-http2-server-http1-client.js>

As you see above, HTTP/2 over HTTP (non-TLS) is rejected.
So, current support is like the following:
HTTPS: HTTP/2 and HTTP/1.1
HTTP: HTTP/1.1

However, most of the clients such as Google Chrome only supports HTTP/2 over HTTPS.

## Test on local

```bash
openssl req -nodes -newkey rsa:2048 -keyout server.key -out server.csr -subj "/C=GB/ST=London/L=London/O=Global Security/OU=IT Department/CN=example.com"
openssl x509 -days 3650 -req -signkey server.key < server.csr > server.crt
npm start -- --enable-https=true --https-port=8443 --key-path=./server.key --crt-path=./server.crt
```

Then, you can access to <https://localhost:8443> and confirm protocol is h2 on Network tab like the following.

![image](https://user-images.githubusercontent.com/10933561/55967680-aba40580-5cb5-11e9-81c2-c7ad044276f2.png)

Here is a multipart test.
![image](https://user-images.githubusercontent.com/10933561/55968086-4e5c8400-5cb6-11e9-8784-b7a045864554.png)

Also command-line.

```bash
curl -v -k --http2 https://192.168.11.3:8443/help
```

Here is curl output.

```txt
*   Trying 192.168.11.3...
* TCP_NODELAY set
* Connected to 192.168.11.3 (192.168.11.3) port 8443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/certs/ca-certificates.crt
  CApath: /etc/ssl/certs
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=GB; ST=London; L=London; O=Global Security; OU=IT Department; CN=example.com
*  start date: Apr 11 14:56:35 2019 GMT
*  expire date: Apr  8 14:56:35 2029 GMT
*  issuer: C=GB; ST=London; L=London; O=Global Security; OU=IT Department; CN=example.com
*  SSL certificate verify result: self signed certificate (18), continuing anyway.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x55e6dc2ea900)
> GET /help HTTP/2
> Host: 192.168.11.3:8443
> User-Agent: curl/7.58.0
> Accept: */*
>
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
< HTTP/2 200
< content-length: 601
< content-type: text/plain
< date: Thu, 11 Apr 2019 15:06:16 GMT
<
Help for piping-server 0.9.5-SNAPSHOT
(Repository: https://github.com/nwtgck/piping-server)

======= Get  =======
curl https://hostname/mypath

======= Send =======
# Send a file
curl -T myfile https://hostname/mypath

# Send a text
echo 'hello!' | curl -T - https://hostname/mypath

# Send a directory (zip)
zip -q -r - ./mydir | curl -T - https://hostname/mypath

# Send a directory (tar.gz)
tar zfcp - ./mydir | curl -T - https://hostname/mypath

# Encryption
## Send
cat myfile | openssl aes-256-cbc | curl -T - https://hostname/mypath
## Get
curl https://hostname/mypath | openssl aes-256-cbc -d
* Connection #0 to host 192.168.11.3 left intact
```