### PR TITLE
Prevent hijacking top page of simple Web UI by Service Worker

### DIFF
--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -166,6 +166,7 @@ describe("piping.Server", () => {
     // Content-length should be returned
     assert.strictEqual(data.headers["content-length"], "this is a content".length.toString());
     assert.strictEqual(data.headers["content-length"], "this is a content".length.toString());
+    assert.strictEqual(data.headers["content-type"], "application/octet-stream");
   });
 
   it("should handle connection over HTTP/2 (receiver O, sender: O)", async () => {

--- a/test/piping.test.ts
+++ b/test/piping.test.ts
@@ -239,6 +239,45 @@ describe("piping.Server", () => {
     assert.strictEqual(data.headers["content-type"], "text/plain");
   });
 
+  it("should attach 'Content-Disposition: attachment' when Content-Type is 'text/html'", async () => {
+    // Get request promise
+    const reqPromise = thenRequest("GET", `${pipingUrl}/mydataid`);
+
+    // Send data
+    await thenRequest("POST", `${pipingUrl}/mydataid`, {
+      headers: {
+        "content-type": "text/html"
+      },
+      body: "<h1>this is a content</h1>"
+    });
+
+    // Get data
+    const data = await reqPromise;
+
+    // Content-Disposition should be 'attachment'
+    assert.strictEqual(data.headers["content-disposition"], "attachment");
+  });
+
+  it("should preserve 'Content-Disposition: attachment; OOO' when Content-Type is 'text/html'", async () => {
+    // Get request promise
+    const reqPromise = thenRequest("GET", `${pipingUrl}/mydataid`);
+
+    // Send data
+    await thenRequest("POST", `${pipingUrl}/mydataid`, {
+      headers: {
+        "content-type": "text/html",
+        "content-disposition": "attachment; filename=\"filename.jpg\""
+      },
+      body: "<h1>this is a content</h1>"
+    });
+
+    // Get data
+    const data = await reqPromise;
+
+    // Content-Disposition should be preserved
+    assert.strictEqual(data.headers["content-disposition"], "attachment; filename=\"filename.jpg\"");
+  });
+
   it("should pass sender's Content-Disposition to receivers' one", async () => {
     // Get request promise
     const reqPromise = thenRequest("GET", `${pipingUrl}/mydataid`);
@@ -871,6 +910,28 @@ describe("piping.Server", () => {
       const getData1 = await getPromise1;
       assert.strictEqual(getData1.statusCode, 200);
       assert.strictEqual(getData1.headers["content-type"], "text/plain");
+    });
+
+    it("should attach 'Content-Disposition: attachment' when Content-Type is 'text/html'", async () => {
+      const formData = {
+        "dummy form name": {
+          value: "<h1>this is a content</h1>",
+          options: {
+            contentType: "text/html"
+          }
+        }
+      };
+
+      // Send data
+      request.post({url: `${pipingUrl}/mydataid`, formData: formData});
+
+      await sleep(10);
+
+      const getPromise1 = thenRequest("GET", `${pipingUrl}/mydataid`);
+
+      const getData1 = await getPromise1;
+      assert.strictEqual(getData1.statusCode, 200);
+      assert.strictEqual(getData1.headers["content-disposition"], "attachment");
     });
 
     it("should pass sender's Content-Disposition to receivers' one", async () => {


### PR DESCRIPTION
## Proof of concept video
![piping-top-hijack-by-service-worker](https://user-images.githubusercontent.com/10933561/63224409-c1df4680-c1fe-11e9-9cee-fc3b94e915fe.gif)

This was reported by @yuta0801. Thanks!
This PR is for preventing this hijacking. **This PR make browsers download HTML content by using `Content-Disposition: attachment`.** So, HTML is never previewed in the browsers.

## References
* (Japansese) <https://scrapbox.io/yuta0801/Piping_Server%E3%81%AE%E3%83%88%E3%83%83%E3%83%97%E3%83%9A%E3%83%BC%E3%82%B8%E3%82%92ServiceWorker%E3%81%A7%E4%B9%97%E3%81%A3%E5%8F%96%E3%82%8B>
* (Japansese) <https://scrapbox.io/nwtgck/%E9%81%A9%E5%BD%93%E3%81%AAHTML%E3%82%92%E8%B8%8F%E3%81%BE%E3%81%9B%E3%81%A6Service_Worker%E3%81%A7Piping_Server%E3%81%AE%E8%B3%AA%E7%B4%A0%E3%81%AAWeb_UI%E3%81%AE%E3%83%88%E3%83%83%E3%83%97%E3%83%9A%E3%83%BC%E3%82%B8%E3%82%92%E6%9B%B8%E3%81%8D%E6%8F%9B%E3%81%88%E3%82%89%E3%82%8C%E3%82%8B%E4%BB%B6%E3%81%AB%E9%96%A2%E3%81%97%E3%81%A6%E6%89%8B%E6%B3%95%2F%E5%8D%B1%E9%99%BA%E6%80%A7%2F%E5%AF%BE%E7%AD%96%E3%81%AA%E3%81%A9>
