### PR TITLE
[change] Use node-version instead of version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Use Node.js 10.x
       uses: actions/setup-node@v1
       with:
-        version: 10.x
+        node-version: 10.x
     - name: npm ci, build, and test
       run: |
         npm ci


### PR DESCRIPTION
'version' has been deprecated on actions/setup-node

Close #201