### PR TITLE
Support browser form restoration

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -54,7 +54,6 @@ Command-line usage:
       deactivatedInput.setAttribute("disabled", "");
       deactivatedInput.style.display = "none";
     }
-    setInputs();
     // Body of toggleInputMode
     function toggle() {
       // Swap inputs
@@ -62,6 +61,14 @@ Command-line usage:
       activeInput      = deactivatedInput;
       deactivatedInput = tmpInput;
       setInputs();
+    }
+    // Support browser form restoration
+    window.onload = function () {
+      if (window.text_mode.checked) {
+        toggle();
+      } else {
+        setInputs();
+      }
     }
     return toggle;
   })();


### PR DESCRIPTION
- Support browser form restoration
  - Now browser can restore form state fully
- Only tested on Chrome
  - Used the "Reopen closed tab" feature on Chrome
  - Need test on the other browsers for preventing browser-dependent
