### PR TITLE
[ci] remove pull_request.types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ name: Node CI
 on:
   push:
   pull_request:
-    types: [opened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,7 @@
 # (base: https://github.com/actions/starter-workflows/blob/ba767afb30b1bceb8c1d6a798d526be9b6f14554/ci/node.js.yml)
 name: Node CI
 
-on:
-  push:
-  pull_request:
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
cf. https://help.github.com/en/actions/reference/events-that-trigger-workflows#pull-request-event-pull_request
> By default, a workflow only runs when a pull_request's activity type is opened, synchronize, or reopened.