### PR TITLE
[change] Remove npm cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ WORKDIR /app
 # (from: https://stackoverflow.com/a/25571391/2885946)
 RUN npm ci && \
     npm run build && \
-    npm prune --production
+    npm prune --production && \
+    rm -rf $(npm config get cache)
 
 # Run a server
 ENTRYPOINT [ "tini", "--", "node", "dist/src/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /app
 RUN npm ci && \
     npm run build && \
     npm prune --production && \
-    rm -rf $(npm config get cache)
+    npm cache clean --force
 
 # Run a server
 ENTRYPOINT [ "tini", "--", "node", "dist/src/index.js" ]


### PR DESCRIPTION
Docker image size was reduced from 110MB to 93.2MB (-16.8MB)