### PR TITLE
reduced size of npm tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,12 +1,15 @@
 {
   "name": "piping-server",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Streaming Data Transfer Server over HTTP/HTTPS",
   "bin": {
     "piping-server": "dist/src/index.js"
   },
   "main": "dist/src/piping.js",
   "types": "dist/src/piping.d.ts",
+  "files": [
+    "dist/src"
+  ],
   "scripts": {
     "generate-version": "sh -c \"echo 'export const VERSION = \\\"${npm_package_version}\\\";' > src/version.ts\"",
     "build": "npm run generate-version && tsc",


### PR DESCRIPTION
Currently, when checking `npm v piping-server@1.2.0`, the unpacked size of the package is 21 MB. Most of the data stored in the tarball is in the form of gif files. This PR removes all the excess and leaves in the following files:
```
LICENSE
dist/src/index.js
dist/src/piping.js
dist/src/resources.js
dist/src/version.js
package.json
dist/src/index.js.map
dist/src/piping.js.map
dist/src/resources.js.map
dist/src/version.js.map
CHANGELOG.md
README.md
dist/src/index.d.ts
dist/src/piping.d.ts
dist/src/resources.d.ts
dist/src/version.d.ts
```